### PR TITLE
Show iex prompt on tty1 for consistency

### DIFF
--- a/rootfs_overlay/etc/erlinit.config
+++ b/rootfs_overlay/etc/erlinit.config
@@ -5,8 +5,8 @@
 
 # Specify where erlinit should send the IEx prompt. Only one may be enabled at
 # a time.
--c ttyS0     # UART pins on the GPIO connector
-#-c tty1      # HDMI output
+#-c ttyS0     # UART pins on the GPIO connector
+-c tty1      # HDMI output
 
 # If more than one tty are available, always warn if the user is looking at the
 # wrong one.


### PR DESCRIPTION
The other non-gadget mode Raspberry Pi systems all output the iex prompt
on the HDMI port. This makes the RPi4 consistent and follow our
instructions.

Thanks to @nicolafiorillo for reporting this.