### PR TITLE
Fix fixup.dat and start.elf naming

### DIFF
--- a/fwup-revert.conf
+++ b/fwup-revert.conf
@@ -48,7 +48,7 @@ define(ROOTFS, "${NERVES_SYSTEM}/images/rootfs.squashfs")
 # | (formatted as uboot env)   |
 # +----------------------------+
 # | p0*: Boot A (FAT32)        |
-# | zImage, start4.elf         |
+# | zImage, start.elf          |
 # | config.txt, etc.           |
 # +----------------------------+
 # | p0*: Boot B (FAT32)        |

--- a/fwup.conf
+++ b/fwup.conf
@@ -38,7 +38,7 @@ define(ROOTFS, "${NERVES_SYSTEM}/images/rootfs.squashfs")
 # | (formatted as uboot env)   |
 # +----------------------------+
 # | p0*: Boot A (FAT32)        |
-# | zImage, start4.elf,        |
+# | zImage, start.elf,         |
 # | config.txt, etc.           |
 # +----------------------------+
 # | p0*: Boot B (FAT32)        |
@@ -93,11 +93,11 @@ meta-misc = ${NERVES_FW_MISC}
 # File resources are listed in the order that they are included in the .fw file
 # This is important, since this is the order that they're written on a firmware
 # update due to the event driven nature of the update system.
-file-resource fixup4.dat {
-    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/fixup4.dat"
+file-resource fixup.dat {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/fixup.dat"
 }
-file-resource start4.elf {
-    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/start4.elf"
+file-resource start.elf {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/start.elf"
 }
 file-resource config.txt {
     host-path = "${NERVES_SYSTEM}/images/config.txt"
@@ -221,8 +221,8 @@ task complete {
 
     on-resource config.txt { fat_write(${BOOT_A_PART_OFFSET}, "config.txt") }
     on-resource cmdline.txt { fat_write(${BOOT_A_PART_OFFSET}, "cmdline.txt") }
-    on-resource start4.elf { fat_write(${BOOT_A_PART_OFFSET}, "start4.elf") }
-    on-resource fixup4.dat { fat_write(${BOOT_A_PART_OFFSET}, "fixup4.dat") }
+    on-resource start.elf { fat_write(${BOOT_A_PART_OFFSET}, "start.elf") }
+    on-resource fixup.dat { fat_write(${BOOT_A_PART_OFFSET}, "fixup.dat") }
     on-resource zImage { fat_write(${BOOT_A_PART_OFFSET}, "kernel7.img") }
     on-resource bcm2711-rpi-4-b.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2711-rpi-4-b.dtb") }
     on-resource rpi-ft5406.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/rpi-ft5406.dtbo") }
@@ -285,8 +285,8 @@ task upgrade.a {
     # won't hurt anything.
     on-resource config.txt { fat_write(${BOOT_A_PART_OFFSET}, "config.txt") }
     on-resource cmdline.txt { fat_write(${BOOT_A_PART_OFFSET}, "cmdline.txt") }
-    on-resource start4.elf { fat_write(${BOOT_A_PART_OFFSET}, "start4.elf") }
-    on-resource fixup4.dat { fat_write(${BOOT_A_PART_OFFSET}, "fixup4.dat") }
+    on-resource start.elf { fat_write(${BOOT_A_PART_OFFSET}, "start.elf") }
+    on-resource fixup.dat { fat_write(${BOOT_A_PART_OFFSET}, "fixup.dat") }
     on-resource zImage { fat_write(${BOOT_A_PART_OFFSET}, "kernel7.img") }
     on-resource bcm2711-rpi-4-b.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2711-rpi-4-b.dtb") }
     on-resource rpi-ft5406.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/rpi-ft5406.dtbo") }
@@ -352,8 +352,8 @@ task upgrade.b {
     # won't hurt anything.
     on-resource config.txt { fat_write(${BOOT_B_PART_OFFSET}, "config.txt") }
     on-resource cmdline.txt { fat_write(${BOOT_B_PART_OFFSET}, "cmdline.txt") }
-    on-resource start4.elf { fat_write(${BOOT_B_PART_OFFSET}, "start4.elf") }
-    on-resource fixup4.dat { fat_write(${BOOT_B_PART_OFFSET}, "fixup4.dat") }
+    on-resource start.elf { fat_write(${BOOT_B_PART_OFFSET}, "start.elf") }
+    on-resource fixup.dat { fat_write(${BOOT_B_PART_OFFSET}, "fixup.dat") }
     on-resource zImage { fat_write(${BOOT_B_PART_OFFSET}, "kernel7.img") }
     on-resource bcm2711-rpi-4-b.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2711-rpi-4-b.dtb") }
     on-resource rpi-ft5406.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/rpi-ft5406.dtbo") }


### PR DESCRIPTION
The naming of these files changed in Buildroot (See
https://git.buildroot.net/buildroot/commit/?id=1bdc0334ff6273761b2e7fda730cdcc7e1f46862).
Change their naming here to match.

Fixes https://circleci.com/gh/nerves-project/nerves_system_rpi4/323?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link.