### PR TITLE
Enable dwc2 for the CM4 I/O board

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -46,3 +46,9 @@ enable_uart=1
 dtoverlay=vc4-fkms-v3d
 max_framebuffers=2
 
+[cm4]
+# Raspberry Pi CM4-only settings
+
+# For the CM4 I/O board, USB is disabled by default. This enables it.
+dtoverlay=dwc2,dr_mode=host
+

--- a/fwup.conf
+++ b/fwup.conf
@@ -132,6 +132,9 @@ file-resource miniuart-bt.dtbo {
 file-resource vc4-fkms-v3d.dtbo {
     host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/vc4-fkms-v3d.dtbo"
 }
+file-resource dwc2.dtbo {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/dwc2.dtbo"
+}
 file-resource ramoops.dtbo {
     host-path = "${NERVES_SYSTEM}/images/ramoops.dtb"
 }
@@ -238,6 +241,7 @@ task complete {
     on-resource w1-gpio-pullup.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }
     on-resource miniuart-bt.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/miniuart-bt.dtbo") }
     on-resource vc4-fkms-v3d.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-fkms-v3d.dtbo") }
+    on-resource dwc2.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/dwc2.dtbo") }
     on-resource ramoops.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/ramoops.dtbo") }
 
     on-resource rootfs.img {
@@ -304,6 +308,7 @@ task upgrade.a {
     on-resource w1-gpio-pullup.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }
     on-resource miniuart-bt.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/miniuart-bt.dtbo") }
     on-resource vc4-fkms-v3d.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-fkms-v3d.dtbo") }
+    on-resource dwc2.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/dwc2.dtbo") }
     on-resource ramoops.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/ramoops.dtbo") }
     on-resource rootfs.img {
         delta-source-raw-offset=${ROOTFS_B_PART_OFFSET}
@@ -377,6 +382,7 @@ task upgrade.b {
     on-resource w1-gpio-pullup.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }
     on-resource miniuart-bt.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/miniuart-bt.dtbo") }
     on-resource vc4-fkms-v3d.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/vc4-fkms-v3d.dtbo") }
+    on-resource dwc2.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/dwc2.dtbo") }
     on-resource ramoops.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/ramoops.dtbo") }
     on-resource rootfs.img {
         delta-source-raw-offset=${ROOTFS_A_PART_OFFSET}


### PR DESCRIPTION
USB is off on the CM4 by default. To turn it on, the dwc2 driver needs to be started in host mode. This turns it on in `config.txt` and adds the `dwc2` overlay to the image