### PR TITLE
Add fwup task to reprovision devices

### DIFF
--- a/fwup.conf
+++ b/fwup.conf
@@ -427,3 +427,16 @@ task upgrade.wrongplatform {
         error("Expecting platform=${NERVES_FW_PLATFORM} and architecture=${NERVES_FW_ARCHITECTURE}")
     }
 }
+
+task provision {
+    require-uboot-variable(uboot-env, "a.nerves_fw_platform", "${NERVES_FW_PLATFORM}")
+    require-uboot-variable(uboot-env, "a.nerves_fw_architecture", "${NERVES_FW_ARCHITECTURE}")
+    on-init {
+        include("${NERVES_PROVISIONING}")
+    }
+}
+task provision.wrongplatform {
+    on-init {
+        error("Expecting platform=${NERVES_FW_PLATFORM} and architecture=${NERVES_FW_ARCHITECTURE}")
+    }
+}


### PR DESCRIPTION
The provision task lets you use `fwup` to re-apply the provisioning
information to a MicroSD card. For example, if you store initial WiFi
credentials using the provisioning feature, then to change them, put the
MicroSD card back in your computer and run:

```sh
NERVES_WIFI_SSID="new_ssid" NERVES_WIFI_PASSPHRASE="new_password" fwup
firmware.fw -t provision
```

This only writes the provisioning data. Nothing else on the MicroSD card
will be changed.
