### PR TITLE
Slim down DRI libs' size

### DIFF
--- a/post-build.sh
+++ b/post-build.sh
@@ -2,6 +2,25 @@
 
 set -e
 
+# replace DRI libs with symlinks to save space
+function slim_down_dri_libs() {
+    pushd $STAGING_DIR/usr/lib/dri/
+
+    for f in *.so; do
+        if [ "$f" = "v3d_dri.so" ]; then
+            continue
+        fi
+
+        rm "$f"
+        ln -s v3d_dri.so "$f"
+    done
+
+    popd
+}
+
+
+slim_down_dri_libs
+
 # Create the revert script for manually switching back to the previously
 # active firmware.
 mkdir -p $TARGET_DIR/usr/share/fwup


### PR DESCRIPTION
Fix for #106 
DRI lib files are all the same and are either copies of each other or hard links when supported it. This PR replaces those copies with simlinks which reduces the archive's size.  
Those simlinks do not seem to affect libs in `target/usr/lib/dri` in any way and are the same files (down to sha checksum) with or without this patch.

Tested on barebones RPi 4 and works, but additional test with some application actually using mesa3d would be nice, but probably not needed since files in the `target` dir aren't affected.