### PR TITLE
Add 4 to RPi firmware files to avoid confusion

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -13,8 +13,8 @@
 arm_64bit=1
 
 # We always use the same names. The variant is selected in fwup.conf.
-start_file=start.elf
-fixup_file=fixup.dat
+start_file=start4.elf
+fixup_file=fixup4.dat
 
 # Disable the boot rainbow
 disable_splash=1

--- a/fwup-revert.conf
+++ b/fwup-revert.conf
@@ -48,7 +48,7 @@ define(ROOTFS, "${NERVES_SYSTEM}/images/rootfs.squashfs")
 # | (formatted as uboot env)   |
 # +----------------------------+
 # | p0*: Boot A (FAT32)        |
-# | kernel8.img, start.elf,    |
+# | kernel8.img, start4.elf,   |
 # | config.txt, etc.           |
 # +----------------------------+
 # | p0*: Boot B (FAT32)        |

--- a/fwup.conf
+++ b/fwup.conf
@@ -38,7 +38,7 @@ define(ROOTFS, "${NERVES_SYSTEM}/images/rootfs.squashfs")
 # | (formatted as uboot env)   |
 # +----------------------------+
 # | p0*: Boot A (FAT32)        |
-# | kernel8.img, start.elf,    |
+# | kernel8.img, start4.elf,   |
 # | config.txt, etc.           |
 # +----------------------------+
 # | p0*: Boot B (FAT32)        |
@@ -93,10 +93,10 @@ meta-misc = ${NERVES_FW_MISC}
 # File resources are listed in the order that they are included in the .fw file
 # This is important, since this is the order that they're written on a firmware
 # update due to the event driven nature of the update system.
-file-resource fixup.dat {
+file-resource fixup4.dat {
     host-path = "${NERVES_SYSTEM}/images/rpi-firmware/fixup4x.dat"
 }
-file-resource start.elf {
+file-resource start4.elf {
     host-path = "${NERVES_SYSTEM}/images/rpi-firmware/start4x.elf"
 }
 file-resource config.txt {
@@ -260,8 +260,8 @@ task complete {
 
     on-resource config.txt { fat_write(${BOOT_A_PART_OFFSET}, "config.txt") }
     on-resource cmdline.txt { fat_write(${BOOT_A_PART_OFFSET}, "cmdline.txt") }
-    on-resource start.elf { fat_write(${BOOT_A_PART_OFFSET}, "start.elf") }
-    on-resource fixup.dat { fat_write(${BOOT_A_PART_OFFSET}, "fixup.dat") }
+    on-resource start4.elf { fat_write(${BOOT_A_PART_OFFSET}, "start4.elf") }
+    on-resource fixup4.dat { fat_write(${BOOT_A_PART_OFFSET}, "fixup4.dat") }
     on-resource kernel8.img { fat_write(${BOOT_A_PART_OFFSET}, "kernel8.img") }
     on-resource bcm2711-rpi-4-b.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2711-rpi-4-b.dtb") }
     on-resource bcm2711-rpi-cm4.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2711-rpi-cm4.dtb") }
@@ -337,8 +337,8 @@ task upgrade.a {
     # won't hurt anything.
     on-resource config.txt { fat_write(${BOOT_A_PART_OFFSET}, "config.txt") }
     on-resource cmdline.txt { fat_write(${BOOT_A_PART_OFFSET}, "cmdline.txt") }
-    on-resource start.elf { fat_write(${BOOT_A_PART_OFFSET}, "start.elf") }
-    on-resource fixup.dat { fat_write(${BOOT_A_PART_OFFSET}, "fixup.dat") }
+    on-resource start4.elf { fat_write(${BOOT_A_PART_OFFSET}, "start4.elf") }
+    on-resource fixup4.dat { fat_write(${BOOT_A_PART_OFFSET}, "fixup4.dat") }
     on-resource kernel8.img { fat_write(${BOOT_A_PART_OFFSET}, "kernel8.img") }
     on-resource bcm2711-rpi-4-b.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2711-rpi-4-b.dtb") }
     on-resource bcm2711-rpi-cm4.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2711-rpi-cm4.dtb") }
@@ -422,8 +422,8 @@ task upgrade.b {
     # won't hurt anything.
     on-resource config.txt { fat_write(${BOOT_B_PART_OFFSET}, "config.txt") }
     on-resource cmdline.txt { fat_write(${BOOT_B_PART_OFFSET}, "cmdline.txt") }
-    on-resource start.elf { fat_write(${BOOT_B_PART_OFFSET}, "start.elf") }
-    on-resource fixup.dat { fat_write(${BOOT_B_PART_OFFSET}, "fixup.dat") }
+    on-resource start4.elf { fat_write(${BOOT_B_PART_OFFSET}, "start4.elf") }
+    on-resource fixup4.dat { fat_write(${BOOT_B_PART_OFFSET}, "fixup4.dat") }
     on-resource kernel8.img { fat_write(${BOOT_B_PART_OFFSET}, "kernel8.img") }
     on-resource bcm2711-rpi-4-b.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2711-rpi-4-b.dtb") }
     on-resource bcm2711-rpi-cm4.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2711-rpi-cm4.dtb") }


### PR DESCRIPTION
The Raspberry Pi 4 start.elf and fixup.dat have 4's in them with
Raspberry Pi OS.

The `config.txt` says what to use so the current setup works.

However, there's a sentence in the
[docs](https://www.raspberrypi.com/documentation/computers/config_txt.html#start_x-start_debug)
that says "On the Raspberry Pi 4, if the files start4x.elf and
fixup4x.dat are present, these files will be used instead [of
start_x.elf and fixup_x.dat)."

That means that if you copy `start4.elf` to the FAT filesystem and leave
the provided `start.elf` there, that `start4.elf` is used in preference
to one in the `config.txt`. This makes sense, but is cause confusion.

Therefore, to avoid any confusion or surprises, add the 4's back to the
names. It's still not 1:1 with the RaspberryPi OS given that the x or
non-x firmware is decided by which file is sourced by the `fwup.conf`,
but it's consistent with other Nerves RPi systems and doesn't have 4
confusion.
